### PR TITLE
encrypted curl download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ apt-get -y -o Dpkg::Options::="--force-confold" install --no-install-recommends 
     libsqlite3-0 \
     unzip \
     locales && \
-curl -sSL http://updates.duplicati.com/canary/duplicati-${DUPLICATI_VER}.zip -o /duplicati-${DUPLICATI_VER}.zip && \
+curl -sSL https://updates.duplicati.com/canary/duplicati-${DUPLICATI_VER}.zip -o /duplicati-${DUPLICATI_VER}.zip && \
 unzip duplicati-${DUPLICATI_VER}.zip -d /app && \
 rm /duplicati-${DUPLICATI_VER}.zip && \
 apt-get purge -y --auto-remove unzip && \


### PR DESCRIPTION
use https instead of http for curl package download